### PR TITLE
Set default preloadedItems type with a sentinel value

### DIFF
--- a/lib/pagination_view.dart
+++ b/lib/pagination_view.dart
@@ -13,7 +13,7 @@ typedef PaginationBuilder<T> = Future<List<T>> Function(int currentListSize);
 enum PaginationViewType { listView, gridView }
 
 class PaginationView<T> extends StatefulWidget {
-  const PaginationView({
+  PaginationView({
     Key key,
     @required this.itemBuilder,
     @required this.pageFetch,
@@ -23,7 +23,7 @@ class PaginationView<T> extends StatefulWidget {
     this.pullToRefresh = false,
     this.gridDelegate =
         const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 2),
-    this.preloadedItems = const [],
+    List<T> preloadedItems,
     this.initialLoader = const InitialLoader(),
     this.bottomLoader = const BottomLoader(),
     this.paginationViewType = PaginationViewType.listView,
@@ -36,7 +36,8 @@ class PaginationView<T> extends StatefulWidget {
     this.scrollController,
     this.header,
     this.footer,
-  }) : super(key: key);
+  })  : preloadedItems = preloadedItems ?? <T>[],
+        super(key: key);
 
   final Widget bottomLoader;
   final Widget footer;


### PR DESCRIPTION
When not declaring a value for `preloadedItems` in a typed PaginationView widget such as the following example: 
```dart
PaginationView<User>(
        key: key,
        header: Text('Header text'),
        footer: Text('Footer text'),
        /**
         * Removing preloadedItems value
         * preloadedItems: <User>[
            User(faker.person.name(), faker.internet.email()),
            User(faker.person.name(), faker.internet.email()),
          ],
        */
        paginationViewType: paginationViewType,
        itemBuilder: (BuildContext context, User user, int index) =>
            (paginationViewType == PaginationViewType.listView)
                ? ListTile(
                    title: Text(user.name),
                    subtitle: Text(user.email),
                    leading: CircleAvatar(
                      child: Icon(Icons.person),
                    ),
                  )
                : GridTile(
                    child: Column(
                      mainAxisSize: MainAxisSize.max,
                      mainAxisAlignment: MainAxisAlignment.center,
                      children: <Widget>[
                        CircleAvatar(child: Icon(Icons.person)),
                        const SizedBox(height: 8),
                        Text(user.name),
                        const SizedBox(height: 8),
                        Text(user.email),
                      ],
                    ),
                  ),
        pageFetch: pageFetch,
        pageRefresh: pageRefresh,
        pullToRefresh: true,
        onError: (dynamic error) => Center(
          child: Text('Some error occured'),
        ),
        onEmpty: Center(
          child: Text('Sorry! This is empty'),
        ),
        bottomLoader: Center(
          child: CircularProgressIndicator(),
        ),
        initialLoader: Center(
          child: CircularProgressIndicator(),
        ),
 ),
```

it throws this exception:

```
E/flutter ( 4530): [ERROR:flutter/lib/ui/ui_dart_state.cc(177)] Unhandled Exception: type 'List<User>' is not a subtype of type 'List<Null>' of 'other'
```  
In order to prevent this from happening, I added a sentinel value to the `PaginationView` constructor which makes sure `preloadedItems` has the correct default type. 