### PR TITLE
Added support for using slivers as a header and footer

### DIFF
--- a/lib/pagination_view.dart
+++ b/lib/pagination_view.dart
@@ -120,14 +120,14 @@ class PaginationViewState<T> extends State<PaginationView<T>> {
       scrollDirection: widget.scrollDirection,
       physics: widget.physics,
       slivers: [
-        if (widget.header != null) SliverToBoxAdapter(child: widget.header),
+        if (widget.header != null) widget.header!,
         SliverPadding(
           padding: widget.padding,
           sliver: widget.paginationViewType == PaginationViewType.gridView
               ? _buildSliverGrid(loadedState)
               : _buildSliverList(loadedState),
         ),
-        if (widget.footer != null) SliverToBoxAdapter(child: widget.footer),
+        if (widget.footer != null) widget.footer!,
       ],
     );
   }


### PR DESCRIPTION
This PR adds support for using a custom sliver as a header and footer, which should solve #22 and allow usage inside a custom scroll view with something like a `SliverAppBar`.