### PR TITLE
prevent unhandled exception

### DIFF
--- a/lib/pagination_view.dart
+++ b/lib/pagination_view.dart
@@ -79,11 +79,13 @@ class PaginationViewState<T> extends State<PaginationView<T>> {
 
   Future<void> refresh() async {
     await _cubit!.refreshPaginatedList();
-    _scrollController!.animateTo(
-      0,
-      curve: Curves.easeIn,
-      duration: const Duration(milliseconds: 200),
-    );
+    if (_scrollController!.hasClients) {
+      _scrollController!.animateTo(
+        0,
+        curve: Curves.easeIn,
+        duration: const Duration(milliseconds: 200),
+      );
+    }
   }
 
   @override


### PR DESCRIPTION
prevent the folowing exception on pull-to-refresh without items

Unhandled Exception: 'package:flutter/src/widgets/scroll_controller.dart': Failed assertion: line 152 pos 12: '_positions.isNotEmpty': ScrollController not attached to any scroll views.